### PR TITLE
ci: use rainix manual-sol-artifacts reusable

### DIFF
--- a/.github/workflows/manual-sol-artifacts.yaml
+++ b/.github/workflows/manual-sol-artifacts.yaml
@@ -1,34 +1,9 @@
 name: Manual sol artifacts
 on:
   workflow_dispatch:
-    inputs:
-
 jobs:
   deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: 0
-
-      - uses: DeterminateSystems/nix-installer-action@v4
-      - uses: DeterminateSystems/magic-nix-cache-action@v2
-
-      - run: nix develop -c rainix-sol-prelude
-      - run: nix develop -c forge selectors up --all
-      - run: nix develop -c forge script script/Deploy.sol:Deploy -vvvvv --slow --broadcast --verify
-        env:
-          DEPLOYMENT_KEY: ${{ github.ref == 'refs/heads/main' && secrets.PRIVATE_KEY || secrets.PRIVATE_KEY_DEV }}
-
-          CI_DEPLOY_ARBITRUM_RPC_URL: ${{ secrets.CI_DEPLOY_ARBITRUM_RPC_URL || vars.CI_DEPLOY_ARBITRUM_RPC_URL || '' }}
-          CI_DEPLOY_BASE_RPC_URL: ${{ secrets.CI_DEPLOY_BASE_RPC_URL || vars.CI_DEPLOY_BASE_RPC_URL || '' }}
-          CI_DEPLOY_BASE_SEPOLIA_RPC_URL: ${{ secrets.CI_DEPLOY_BASE_SEPOLIA_RPC_URL || vars.CI_DEPLOY_BASE_SEPOLIA_RPC_URL || '' }}
-          CI_DEPLOY_FLARE_RPC_URL: ${{ secrets.CI_DEPLOY_FLARE_RPC_URL || vars.CI_DEPLOY_FLARE_RPC_URL || '' }}
-          CI_DEPLOY_POLYGON_RPC_URL: ${{ secrets.CI_DEPLOY_POLYGON_RPC_URL || vars.CI_DEPLOY_POLYGON_RPC_URL || '' }}
-
-          CI_DEPLOY_ARBITRUM_ETHERSCAN_API_KEY: ${{ secrets.CI_DEPLOY_ARBITRUM_ETHERSCAN_API_KEY || vars.CI_DEPLOY_ARBITRUM_ETHERSCAN_API_KEY || '' }}
-          CI_DEPLOY_BASE_ETHERSCAN_API_KEY: ${{ secrets.CI_DEPLOY_BASE_ETHERSCAN_API_KEY || vars.CI_DEPLOY_BASE_ETHERSCAN_API_KEY || '' }}
-          CI_DEPLOY_BASE_SEPOLIA_ETHERSCAN_API_KEY: ${{ secrets.CI_DEPLOY_BASE_SEPOLIA_ETHERSCAN_API_KEY || vars.CI_DEPLOY_BASE_SEPOLIA_ETHERSCAN_API_KEY || '' }}
-          CI_DEPLOY_FLARE_ETHERSCAN_API_KEY: ${{ secrets.CI_DEPLOY_FLARE_ETHERSCAN_API_KEY || vars.CI_DEPLOY_FLARE_ETHERSCAN_API_KEY || '' }}
-          CI_DEPLOY_POLYGON_ETHERSCAN_API_KEY: ${{ secrets.CI_DEPLOY_POLYGON_ETHERSCAN_API_KEY || vars.CI_DEPLOY_POLYGON_ETHERSCAN_API_KEY || '' }}
+    uses: rainlanguage/rainix/.github/workflows/rainix-manual-sol-artifacts.yaml@main
+    with:
+      suite: clone-factory
+    secrets: inherit

--- a/script/Deploy.sol
+++ b/script/Deploy.sol
@@ -7,6 +7,9 @@ import {CloneFactory} from "../src/concrete/CloneFactory.sol";
 import {LibRainDeploy} from "rain-deploy-0.1.2/src/lib/LibRainDeploy.sol";
 import {LibCloneFactoryDeploy} from "../src/lib/LibCloneFactoryDeploy.sol";
 
+/// @dev Hash of the "clone-factory" deployment suite string.
+bytes32 constant DEPLOYMENT_SUITE_CLONE_FACTORY = keccak256("clone-factory");
+
 /// @title Deploy
 /// @notice A script that deploys a CloneFactory.
 contract Deploy is Script {
@@ -15,16 +18,23 @@ contract Deploy is Script {
     function run() external {
         uint256 deployerPrivateKey = vm.envUint("DEPLOYMENT_KEY");
 
-        LibRainDeploy.deployAndBroadcast(
-            vm,
-            LibRainDeploy.supportedNetworks(),
-            deployerPrivateKey,
-            type(CloneFactory).creationCode,
-            "src/concrete/CloneFactory.sol:CloneFactory",
-            LibCloneFactoryDeploy.CLONE_FACTORY_DEPLOYED_ADDRESS,
-            LibCloneFactoryDeploy.CLONE_FACTORY_DEPLOYED_CODEHASH,
-            new address[](0),
-            sDepCodeHashes
-        );
+        bytes32 suite = keccak256(bytes(vm.envOr("DEPLOYMENT_SUITE", string("clone-factory"))));
+        if (suite == DEPLOYMENT_SUITE_CLONE_FACTORY) {
+            LibRainDeploy.deployAndBroadcast(
+                vm,
+                LibRainDeploy.supportedNetworks(),
+                deployerPrivateKey,
+                type(CloneFactory).creationCode,
+                "src/concrete/CloneFactory.sol:CloneFactory",
+                LibCloneFactoryDeploy.CLONE_FACTORY_DEPLOYED_ADDRESS,
+                LibCloneFactoryDeploy.CLONE_FACTORY_DEPLOYED_CODEHASH,
+                new address[](0),
+                sDepCodeHashes
+            );
+        } else {
+            revert(
+                "Invalid deployment suite specified. Please set the DEPLOYMENT_SUITE environment variable to 'clone-factory'."
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Replace per-repo manual-sol-artifacts.yaml with a thin wrapper around the upstream rainix-manual-sol-artifacts.yaml reusable; suite=clone-factory is hardcoded since this repo only deploys one thing.
- Add a DEPLOYMENT_SUITE dispatch in script/Deploy.sol so the reusable's env var routes to the single CloneFactory branch.

## Test plan
- After merge, run the workflow on main to confirm the reusable produces the same deploy result as the old workflow.

Generated with Claude Code.