### PR TITLE
Fix "initilize" typo in V1/V2 interface NatSpec

### DIFF
--- a/src/interface/ICloneableV2.sol
+++ b/src/interface/ICloneableV2.sol
@@ -22,7 +22,7 @@ interface ICloneableV2 {
     /// `ICloneableV2` MUST take appropriate measures to ensure that functions
     /// called before initialize are safe to do so, or revert.
     ///
-    /// To be fully generic, `initilize` accepts `bytes` and so MUST ABI decode
+    /// To be fully generic, `initialize` accepts `bytes` and so MUST ABI decode
     /// within the initialize function. This allows a single factory to service
     /// arbitrary cloneable proxies but also erases the type of the
     /// initialization config from the ABI. As tooling will inevitably require

--- a/src/interface/deprecated/ICloneableV1.sol
+++ b/src/interface/deprecated/ICloneableV1.sol
@@ -16,7 +16,7 @@ interface ICloneableV1 {
     /// `ICloneableV1` MUST take appropriate measures to ensure that functions
     /// called before initialize are safe to do so, or revert.
     ///
-    /// To be fully generic `initilize` accepts `bytes` and so MUST ABI decode
+    /// To be fully generic `initialize` accepts `bytes` and so MUST ABI decode
     /// within the initialize function. This allows the factory to service
     /// arbitrary cloneable proxies but also erases the type of the
     /// initialization config from the ABI. One workaround is to emit an event


### PR DESCRIPTION
Closes #32.

Fixes the `initilize` → `initialize` typo in NatSpec comments:
- `src/interface/ICloneableV2.sol:25`
- `src/interface/deprecated/ICloneableV1.sol:19`

Comments only — no ABI / signature change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed spelling inconsistencies in code documentation comments within interface files for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->