### PR TITLE
test: mutation-harden CloneFactory coverage

### DIFF
--- a/audit/mutation-test-scans.json
+++ b/audit/mutation-test-scans.json
@@ -1,0 +1,22 @@
+[
+  {
+    "timestamp": "2026-06-15T01:28:05Z",
+    "commit": "59a6c4b817c605491980806244860c23b171afde",
+    "publishedTag": "v0.1.1",
+    "commitsAheadOfTag": 8,
+    "scope": "whole repo (CloneFactory.clone + LibCloneFactoryDeploy constants; only logic/constant-bearing units)",
+    "tool": "adversarial-mutation-test",
+    "skillVersion": "0.24.0",
+    "summary": {
+      "behaviours": 14,
+      "mutantsProbed": 14,
+      "mutantsKilledByExistingTests": 14,
+      "survivingMutants": 0,
+      "newTestsAdded": 0,
+      "candidates": 0,
+      "confirmed": 0,
+      "filed": [],
+      "verdict": "saturated — every behaviour pinned by an existing discriminating test; adversarial pass (reentrancy, liar-fallback) found no bug"
+    }
+  }
+]


### PR DESCRIPTION
## Summary

Scoped adversarial-mutation-test coverage pass over `rain.factory`. Result: the test suite for the only logic/constant-bearing units is **mutation-saturated** — every targeted mutation is already killed by an existing discriminating test, so **no new coverage tests were warranted**. This PR lands only the committed scan record (`audit/mutation-test-scans.json`) so org-wide health tracking can see this repo was scanned at this commit and found saturated. **No source or test changes.**

Scanned commit: `59a6c4b` (8 commits ahead of `v0.1.1`).

## Scope surveyed

- `src/concrete/CloneFactory.sol` — `clone(address,bytes)`, the only logic-bearing function. `forge coverage`: 100% lines/statements/branches/funcs.
- `src/lib/LibCloneFactoryDeploy.sol` — the deterministic deploy `CLONE_FACTORY_DEPLOYED_ADDRESS` + `CLONE_FACTORY_DEPLOYED_CODEHASH` constants.
- Interfaces (incl. `deprecated/`) and `script/Deploy.sol` — no in-scope testable logic (pure interfaces / deploy script).

Note: this factory has **no create2 / deterministic-clone path, no address-prediction, and no registry/dedup** — only the CREATE clone path exists, so those behaviour categories are N/A here.

## Mutation matrix (all KILLED — 0 survivors)

| # | Behaviour | Mutation | Killed by |
|---|-----------|----------|-----------|
| B1a | zero-code guard | `code.length == 0` → `!= 0` | `testZeroImplementationCodeSizeError` + clone tests |
| B1b | zero-code guard | guard never fires (`== 0` → `== 1`) | `testZeroImplementationCodeSizeError` (downstream dataless revert) + `testCloneUninitializableFails` |
| B2 | clone target | `Clones.clone(implementation)` → `clone(msg.sender)` | `testCloneBytecode` (asserts proxy impl addr) |
| B3a | NewClone emit | drop the `emit` | `testCloneInitializeEvent` (`entries.length` 0≠1) |
| B3b | NewClone emit | wrong `sender` arg | `testCloneInitializeEvent` (exact `abi.encode` data) |
| B3c | NewClone emit | wrong `clone` arg | `testCloneInitializeEvent` (exact `abi.encode` data) |
| B4a | init success check | `!= ICLONEABLE_V2_SUCCESS` → `==` | clone success tests + `testCloneInitializeFailureFails` |
| B4b | init success check | branch never reverts (`if (false)`) | `testCloneInitializeFailureFails` + `testCloneInitializeData` |
| B4c | init success check | wrong success constant | clone success tests (success path reverts) |
| B5 | return value | `return child` → `return implementation` | `testCloneBytecode` + `testCloneInitializeData` + `testCloneInitializeEvent` |
| B6 | error identity | init-fail revert wrong selector | `testCloneInitializeFailureFails` (exact selector) |
| B6b | error identity | zero-code revert wrong selector | `testZeroImplementationCodeSizeError` (exact selector) |
| LB1b | deploy address | valid-checksum wrong `CLONE_FACTORY_DEPLOYED_ADDRESS` | `testDeployAddress` (recomputes deterministic addr from real creationCode) |
| LB2 | deploy codehash | wrong `CLONE_FACTORY_DEPLOYED_CODEHASH` | `testDeployAddress` + `testExpectedCodeHash` |

(A single-nibble flip of the deploy address is an invalid mutation — it fails the EVM checksum at compile time — so LB1 was re-done as LB1b with a re-checksummed distinct address.)

## Adversarial correctness pass (found no bug)

Derived intended behaviour from the `ICloneableFactoryV2` / `ICloneableV2` NatSpec and falsification-tested against the real factory (throwaway probes, not committed):
- **Reentrancy** — reentering the stateless factory during `initialize` produces two distinct, correctly-pointed proxies and two `NewClone` events. No cross-call corruption.
- **"Liar" fallback** — a contract whose fallback returns the magic success value for any call is accepted. This is spec-acknowledged (the magic-hash guards accidents, not malice), not a divergence.

No accounting/conservation/isolation/ordering issues apply (stateless, single-call, no value handling).

## Verification
- `forge build`: clean.
- `forge fmt --check`: clean.
- `forge test`: 8 pass / 5 fail — the 5 failures are the `LibCloneFactoryDeployProd` fork tests, which require `*_RPC_URL` secrets not present in this environment (env-gated, pre-existing). Non-fork suite is green.
- `git diff src/`: empty (all mutations restored; no source touched).

## Remaining gaps checklist
- [x] CloneFactory.clone — every behaviour mutation-validated, no survivors.
- [x] LibCloneFactoryDeploy constants — both pinned to the recomputed deterministic address/codehash.
- [ ] `script/Deploy.sol` — 0% covered, but it is a deployment script (out of test-only scope); not hardened here.
- [ ] `LibCloneFactoryDeployProd` fork tests — could not run (no RPC secrets); unverified in this environment.

**Do not merge for coverage** — there are no new tests. This is a scan-record-only PR documenting that the suite is saturated; merge only if you want the health-tracking record landed on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Recorded mutation test scan results confirming comprehensive test coverage with all mutants eliminated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->